### PR TITLE
fixed inconsistent naming in example (minor change)

### DIFF
--- a/_posts/2016-05-24-getting-started.md
+++ b/_posts/2016-05-24-getting-started.md
@@ -270,7 +270,7 @@ elements: [
     data: {
       id: 'ac',
       source: 'a',
-      target: 'd'
+      target: 'c'
     }
   },
   {

--- a/public/demos/getting-started/index-layout.html
+++ b/public/demos/getting-started/index-layout.html
@@ -57,7 +57,7 @@
               data: {
                 id: 'ac',
                 source: 'a',
-                target: 'd'
+                target: 'c'
               }
             },
             {


### PR DESCRIPTION
id of connection a → d was ac. Changed connection to a → c.

I think this change is just a typo which may confusing some people which use your example. One could do the example with ad instead of ac too.