### PR TITLE
Fix links for the blog post

### DIFF
--- a/_posts/2022-09-13-3.23.0-release.md
+++ b/_posts/2022-09-13-3.23.0-release.md
@@ -8,4 +8,4 @@ tags:
 
 Cytoscape.js 3.23.0 has been released.  This version adds support for [conveniently creating graph elements that are not yet added to the graph instance](https://github.com/cytoscape/cytoscape.js/issues/3019), as contributed by [@Alexithemia](https://github.com/Alexithemia).
 
-The full list of changes can be found in the [3.23.0 milestone on GitHub]([https://github.com/cytoscape/cytoscape.js/milestone/226?closed=1](https://github.com/cytoscape/cytoscape.js/milestone/229?closed=1)).
+The full list of changes can be found in the [3.23.0 milestone on GitHub](https://github.com/cytoscape/cytoscape.js/milestone/229?closed=1).


### PR DESCRIPTION
The links to the GitHub milestone is broken here. https://blog.js.cytoscape.org/2022/09/13/3.23.0-release/